### PR TITLE
Another try at fixing the CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ roverd = [ "roverd[video,ouster,ros]" ]
 roverp = [ "roverp[graphics,pcd,ply,semseg]" ]
 
 docs = [
+    "abstract-dataloader >= 0.4.0",
     "mkdocs == 1.6.*",
     "mkdocs-material == 9.6.*",
     "mkdocstrings-python-xref == 1.16.3",

--- a/uv.lock
+++ b/uv.lock
@@ -2092,6 +2092,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "abstract-dataloader" },
     { name = "griffe" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -2110,6 +2111,7 @@ roverp = [
 
 [package.metadata]
 requires-dist = [
+    { name = "abstract-dataloader", marker = "extra == 'docs'", specifier = ">=0.4.0" },
     { name = "coverage", marker = "extra == 'dev'" },
     { name = "griffe", marker = "extra == 'docs'", specifier = "==1.8.0" },
     { name = "ipykernel", marker = "extra == 'dev'" },


### PR DESCRIPTION
Turns out `abstract-dataloader` is needed for docs since we have it in `preload_modules`