### PR TITLE
Image Downsampling

### DIFF
--- a/format/src/roverd/channels/__init__.py
+++ b/format/src/roverd/channels/__init__.py
@@ -86,7 +86,7 @@ def from_config(  # noqa: D417
 
 
 __all__ = [
-    "abstract", "utils",
+    "abstract", "utils", "Channel",
     "RawChannel", "LzmaChannel", "LzmaFrameChannel", "VideoChannel",
     "NPZBlobChannel", "JPEGBlobChannel",
 ]

--- a/format/src/roverd/sensors/generic.py
+++ b/format/src/roverd/sensors/generic.py
@@ -35,6 +35,7 @@ class Sensor(abstract.Sensor[TSample, TMetadata]):
             [`roverd.timestamps`][roverd.timestamps]), or `None`.
         past: number of past samples to include.
         future: number of future samples to include.
+        args: additional arguments to pass to channel constructors.
 
     Attributes:
         path: path to sensor data directory.
@@ -46,7 +47,8 @@ class Sensor(abstract.Sensor[TSample, TMetadata]):
         self, path: str,
         correction: str | None | Callable[
             [Float64[np.ndarray, "N"]], Float64[np.ndarray, "N"]] = None,
-        past: int = 0, future: int = 0
+        past: int = 0, future: int = 0,
+        args: dict[str, dict] = {}
     ) -> None:
 
         self.path = path
@@ -60,6 +62,11 @@ class Sensor(abstract.Sensor[TSample, TMetadata]):
         except (FileNotFoundError, json.JSONDecodeError) as e:
             raise ValueError(
                 "{}: no valid 'metadata.json' found.".format(str(e)))
+
+        # Merge additional args into config for each channel
+        for name, channel_args in args.items():
+            if name in self.config:
+                self.config[name]['args'] = channel_args
 
         self.channels = {
             name: channels.from_config(

--- a/format/src/roverd/transforms/ouster.py
+++ b/format/src/roverd/transforms/ouster.py
@@ -34,23 +34,23 @@ class ConfigCache:
         # Safe to ignore errors which can occur in rare circumstances for
         # unknown reasons (possibly related to underlying race conditions in
         # ouster-sdk)
-        try:
-            # ouster-sdk is a naughty, noisy library
-            # it is in fact so noisy, that we have cut it off at the os level...
-            stdout = os.dup(1)
-            os.close(1)
-        except Exception as e:
-            stdout = None
-            warnings.warn(f"Could not suppress ouster-sdk stdout: {e}")
+        # try:
+        #     # ouster-sdk is a naughty, noisy library
+        #     # it is in fact so noisy, that we have cut it off at the os level...
+        #     stdout = os.dup(1)
+        #     os.close(1)
+        # except Exception as e:
+        #     stdout = None
+        #     warnings.warn(f"Could not suppress ouster-sdk stdout: {e}")
 
         info = client.SensorInfo(cfg)  # type: ignore
 
-        if stdout is not None:
-            try:
-                os.dup2(stdout, 1)
-                os.close(stdout)
-            except Exception as e:
-                warnings.warn(f"Could not restore ouster-sdk stdout: {e}")
+        # if stdout is not None:
+        #     try:
+        #         os.dup2(stdout, 1)
+        #         os.close(stdout)
+        #     except Exception as e:
+        #         warnings.warn(f"Could not restore ouster-sdk stdout: {e}")
 
         return info
 

--- a/format/tests/test_trace.py
+++ b/format/tests/test_trace.py
@@ -36,7 +36,9 @@ def test_dataset_api(test_trace_path, smooth):
             "camera": partial(sensors.Camera, correction="auto"),
             "imu": partial(sensors.IMU, correction="auto"),}
     else:
-        spec = {"radar": "auto", "lidar": "auto", "camera": "auto", "imu": "auto"}
+        spec = {
+            "radar": "auto", "lidar": "auto",
+            "camera": "auto", "imu": "auto"}
 
     dataset = Dataset.from_config(
         [test_trace_path], sync=generic.Nearest("lidar"),

--- a/format/tests/test_trace.py
+++ b/format/tests/test_trace.py
@@ -82,6 +82,31 @@ def test_oslidar(test_trace_path):
         _check_shape(sample["lidar"], key, "lidar", ch)
 
 
+def test_camera_resolution(test_trace_path):
+    """Test reading camera data with resolution control."""
+    # Read original resolution
+    trace_full = Trace.from_config(
+        test_trace_path, sync=generic.Nearest("camera"),
+        sensors={"camera": sensors.Camera})
+    sample_full = trace_full[3]
+    assert isinstance(sample_full["camera"], types.CameraData)
+    original_shape = sample_full["camera"].image.shape[2:]  # (height, width, channels)
+
+    # Read with custom resolution (half size)
+    target_resolution = (original_shape[1] // 2, original_shape[0] // 2)  # (width, height)
+    trace_resized = Trace.from_config(
+        test_trace_path, sync=generic.Nearest("camera"),
+        sensors={"camera": partial(sensors.Camera, resolution=target_resolution)})
+    sample_resized = trace_resized[3]
+    assert isinstance(sample_resized["camera"], types.CameraData)
+
+    # Check that resolution was applied: (batch, time, height, width, channels)
+    expected_shape = (target_resolution[1], target_resolution[0], original_shape[2])
+    actual_shape = sample_resized["camera"].image.shape[2:]
+    assert actual_shape == expected_shape, \
+        f"Expected shape {expected_shape}, got {actual_shape}"
+
+
 def test_trace_generic(test_trace_path):
     """Test reading a trace with generic sensors."""
     def _check_shape(sample, sensor, channel):


### PR DESCRIPTION
Add pre-accumulation video downsampling (#36) for memory efficiency without requiring full video re-encoding, e.g. for resolution ablations.